### PR TITLE
Fix calculation for total requests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ This setting uses the [`constant-arrival-rate` scenario](https://grafana.com/doc
 
 Given that each iteration executes only one Pizza request, the test will run 20 requests per second. Mathematically speaking:
 - 20 iterations per second x 1 request per iteration = 20 requests per second 
-- 20 requests per second x 20 second = 200 requests
+- 20 requests per second x 10 second = 200 requests
 
 Run the test. After completion, you can see the test request rate by looking at the `http_reqs` metric, which reports the number of http requests and the request rate. In our example, it is close to our goal of 20 requests per second.
 


### PR DESCRIPTION
Calculation looks wrong in readme file for scenarios example for request rate. 